### PR TITLE
Issue 27 - Feature/27/add complex search

### DIFF
--- a/src/controllers/projectsController.js
+++ b/src/controllers/projectsController.js
@@ -11,20 +11,23 @@ const displaySearchProjects = asyncWrapper(async (req, res) => {
 
     if (search) {
         const searchWords = search.split(" ");
-        const regexQueries = searchWords.map(word => ({
-            $or: [ //$or condition: if it matches any of the conditions listed within the array
-                { title: { $regex: word, $options: 'i' } }, //case-insensitive search
-                { description: { $regex: word, $options: 'i' } },
-                { "technologies.frontend":{ $regex: word, $options: 'i' } }, 
-                { "technologies.backend": { $regex: word, $options: 'i' } }, 
-                { "technologies.design":{ $regex: word, $options: 'i' } }, 
-                { "technologies.projectManagement":{ $regex: word, $options: 'i' } }, 
-                { "technologies.devOps": { $regex: word, $options: 'i' } }, 
-                { "technologies.qualityAssurance": { $regex: word, $options: 'i' } }, 
-                { "technologies.database":{ $regex: word, $options: 'i' } }, 
-                { rolesNeeded:{ $regex: word, $options: 'i' } }, 
-            ]
-        }));
+        const regexQueries = searchWords.map(word => {
+            const regexPattern = new RegExp(word, 'i');
+                    return {
+                $or: [ //$or condition: if it matches any of the conditions listed within the array
+                    { title: { $regex: regexPattern } },
+                    { description: { $regex: regexPattern } },
+                    { "technologies.frontend": { $regex: regexPattern } },
+                    { "technologies.backend": { $regex: regexPattern } },
+                    { "technologies.design": { $regex: regexPattern } },
+                    { "technologies.projectManagement": { $regex: regexPattern } },
+                    { "technologies.devOps": { $regex: regexPattern } },
+                    { "technologies.qualityAssurance": { $regex: regexPattern } },
+                    { "technologies.database": { $regex: regexPattern } },
+                    { rolesNeeded: { $regex: regexPattern } },
+                ]
+            };
+        });
 
         //perform the query with prioritization
         try {

--- a/src/controllers/projectsController.js
+++ b/src/controllers/projectsController.js
@@ -17,6 +17,7 @@ const displaySearchProjects = asyncWrapper(async (req, res) => {
                 $or: [ //$or condition: if it matches any of the conditions listed within the array
                     { title: { $regex: regexPattern } },
                     { description: { $regex: regexPattern } },
+                    { status: { $regex: regexPattern } },
                     { "technologies.frontend": { $regex: regexPattern } },
                     { "technologies.backend": { $regex: regexPattern } },
                     { "technologies.design": { $regex: regexPattern } },

--- a/src/controllers/projectsController.js
+++ b/src/controllers/projectsController.js
@@ -5,118 +5,119 @@ const { StatusCodes } = require("http-status-codes");
 const displaySearchProjects = asyncWrapper(async (req, res) => {
     let { page, limit, search } = req.query;
 
-    // convert page and limit to numbers, with defaults
     page = Number(page) || 1;
-    limit = Number(limit) || 5;
+    limit = Number(limit) || 10;
     const skip = (page - 1) * limit;
 
-    const sortOrder = {
-        "Seeking Team Members": 1,
-        "Completed": 2,
-        "In Progress": 3
-    };
-    
-
-    let matchConditions = [];
     if (search) {
-        //split the search string into individual words
         const searchWords = search.split(" ");
-        //construct regex match conditions for each word for partial matches
-        searchWords.forEach(word => {
-            const regexPattern = new RegExp(word, 'i'); //case-insensitive match
-            matchConditions.push({
-                $or: [
-                    { title: { $regex: regexPattern }},
-                    { description: { $regex: regexPattern }},
-                    { "technologies.frontend": { $regex: regexPattern } },
-                    { "technologies.backend": { $regex: regexPattern } },
-                    { "technologies.design": { $regex: regexPattern } },
-                    { "technologies.projectManagement": { $regex: regexPattern } },
-                    { "technologies.devOps": { $regex: regexPattern } },
-                    { "technologies.qualityAssurance": { $regex: regexPattern } },
-                    { "technologies.database": { $regex: regexPattern } },
-                    { rolesNeeded: { $regex: regexPattern } }
-                ]
+        const regexQueries = searchWords.map(word => ({
+            $or: [ //$or condition: if it matches any of the conditions listed within the array
+                { title: { $regex: word, $options: 'i' } }, //case-insensitive search
+                { description: { $regex: word, $options: 'i' } },
+                { "technologies.frontend":{ $regex: word, $options: 'i' } }, 
+                { "technologies.backend": { $regex: word, $options: 'i' } }, 
+                { "technologies.design":{ $regex: word, $options: 'i' } }, 
+                { "technologies.projectManagement":{ $regex: word, $options: 'i' } }, 
+                { "technologies.devOps": { $regex: word, $options: 'i' } }, 
+                { "technologies.qualityAssurance": { $regex: word, $options: 'i' } }, 
+                { "technologies.database":{ $regex: word, $options: 'i' } }, 
+                { rolesNeeded:{ $regex: word, $options: 'i' } }, 
+            ]
+        }));
+
+        //perform the query with prioritization
+        try {
+            //find documents that match all search terms first
+            //$and condition: if it matches all the conditions listed within the array
+            const allMatches = await Project.find({ $and: regexQueries })
+                                            .skip(skip)
+                                            .limit(limit);
+
+            //collect IDs of all matched projects to exclude them in the next query
+            const excludedIds = allMatches.map(project => project._id);
+
+            let results = allMatches;
+
+            //check if there is room to include more projects in the results on the page
+            if (allMatches.length < limit) {
+                //find documents that match any search terms
+                const anyMatches = await Project.find({
+                    $and: [
+                        { _id: { $nin: excludedIds } }, //exclude already matched projects
+                        { $or: regexQueries }
+                    ]
+                })
+                .skip(skip)
+                .limit(limit - allMatches.length);
+
+                const findMissingWords = (sourceText, searchWords) => {
+                    return searchWords.filter(word =>
+                        !sourceText.toLowerCase().includes(word.toLowerCase())
+                    );
+                };
+                
+                const buildSearchableTextFromProject = (project) => {
+                    let searchableTextComponents = [project.title, project.description];
+                
+                    const techFields = ['frontend', 'backend', 'design', 'projectManagement', 'devOps', 'qualityAssurance', 'database'];
+                    techFields.forEach(field => {
+                        if (project.technologies && project.technologies[field]) {
+                            searchableTextComponents.push(...project.technologies[field]);
+                        }
+                    });
+                
+                    if (project.rolesNeeded && project.rolesNeeded.length > 0) {
+                        searchableTextComponents.push(...project.rolesNeeded);
+                    }
+                
+                    return searchableTextComponents.join(' ');
+                };
+                
+                //enhance anyMatches with missing words information
+                const enhancedAnyMatches = anyMatches.map(project => {
+                    const searchableText = buildSearchableTextFromProject(project);
+                
+                    const missingWords = findMissingWords(searchableText, searchWords);
+                
+                    return {
+                        //convert to a plain object to add a custom property which is outside the scope of database operations
+                        ...project.toObject(), 
+                        missingWords 
+                    };
+                });
+                
+                results = [...allMatches, ...enhancedAnyMatches];
+            }
+
+            const totalProjects = await Project.countDocuments({ $or: regexQueries });
+            const totalPages = Math.ceil(totalProjects / limit);
+
+            res.status(StatusCodes.OK).json({
+                count: results.length,
+                totalPages,
+                page,
+                limit,
+                data: results,
             });
+        } catch (error) {
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: error.message });
+        }
+    } else {
+        //handle the case where no search term is provided
+        const projects = await Project.find().skip(skip).limit(limit);
+        const totalProjects = await Project.countDocuments();
+        const totalPages = Math.ceil(totalProjects / limit);
+
+        res.status(StatusCodes.OK).json({
+            count: projects.length,
+            totalPages,
+            page,
+            limit,
+            data: projects,
         });
     }
-
-
-    // make aggregation pipeline sorting projects
-    const pipeline = matchConditions.length > 0 ? [
-        {
-            // Use $match with $and to ensure all regex conditions are met
-            $match: {
-                $and: matchConditions
-            }
-        },
-        {
-            //$addFields stage is used to add new fields to the documents
-            $addFields: {
-                //add a sortOrder field to each document based on the sorting logic defined by the $switch operator.
-                sortOrder: {
-                    $switch: {
-                        branches: [
-                            { case: { $eq: ["$status", "Seeking Team Members"] }, then: sortOrder["Seeking Team Members"] },
-                            { case: { $eq: ["$status", "Completed"] }, then: sortOrder["Completed"] },
-                            { case: { $eq: ["$status", "In Progress"] }, then: sortOrder["In Progress"] }
-                        ],
-                        default: 4
-                    }
-                }
-            }
-        },
-        {
-            $sort: { sortOrder: 1 }
-        },
-        {
-            $skip: skip //implement pagination by skipping a certain number of documents to preserve correct pagination
-        },
-        {
-            $limit: limit //limit the number of documents passed to the next stage to preserve correct pagination
-        }
-    ] : [
-        {
-            $addFields: {
-                //add a sortOrder field to each document based on the sorting logic defined by the $switch operator.
-                sortOrder: {
-                    $switch: {
-                        branches: [
-                            { case: { $eq: ["$status", "Seeking Team Members"] }, then: sortOrder["Seeking Team Members"] },
-                            { case: { $eq: ["$status", "Completed"] }, then: sortOrder["Completed"] },
-                            { case: { $eq: ["$status", "In Progress"] }, then: sortOrder["In Progress"] }
-                        ],
-                        default: 4
-                    }
-                }
-            }
-        },
-        {
-            $skip: skip //implement pagination by skipping a certain number of documents to preserve correct pagination
-        },
-        {
-            $limit: limit //limit the number of documents passed to the next stage to preserve correct pagination
-        }
-    ]
-
-    //execute the aggregation pipeline
-    let projects = await Project.aggregate(pipeline);
-
-    //count total matching documents for pagination
-    const totalProjects = await Project.countDocuments(search ? { $and: matchConditions } : {});
-    
-    //calculate total pages
-    const totalPages = Math.ceil(totalProjects / limit);
-    console.log(typeof search); //object
-    //return paginated, sorted search results
-    res.status(StatusCodes.OK).json({
-        count: projects.length,
-        totalPages,
-        page,
-        limit,
-        data: projects,
-    });
-})
+});
 
 module.exports =  { displaySearchProjects };
 


### PR DESCRIPTION
In Postman:
1) search by several parameters like  http://localhost:3000/api/v1/projects?search=react+figma+jira
2) the outcome can be paginated  http://localhost:3000/api/v1/projects?search=react+redux+figma&page=1&limit=1 
3) search results should be sorted by matching order.  For ex, if you search for react+redux+node, first you see the full matching results, then, if, for ex., node is absent, the results should be shown in following order: react+redux, react, redux (or vice versa - redux, react). 
4) each result should have a word/words that is/are missing from the search words (if react+redux+node and results show only react+redux then node is missing)
5) on this route you can fetch the projects without any parameters http://localhost:3000/api/v1/projects